### PR TITLE
Prints error messages in terminal if job submission fails

### DIFF
--- a/slurmpy/slurmpy.py
+++ b/slurmpy/slurmpy.py
@@ -168,14 +168,18 @@ class Slurm(object):
                 mid = "--dependency=afternotok:%d" % job_id
                 args.append(mid)
             args.append(sh.name)
-            res = subprocess.check_output(args).strip()
-            print(res, file=sys.stderr)
-            self.name = n
-            if not res.startswith(b"Submitted batch"):
-                return None
-            j_id = int(res.split()[-1])
-            if itry == 1:
-                job_id = j_id
+            try:
+                res = subprocess.check_output(args).strip()
+                print(res.decode(), file=sys.stderr)
+                self.name = n
+                if not res.startswith(b"Submitted batch"):
+                    return None
+                j_id = int(res.split()[-1])
+                if itry == 1:
+                    job_id = j_id
+            except Exception as e:
+                print ("\x1B[31;9m" + 'Error submitting job:' + "\x1B[0m\n")
+                print(e.output.decode())
         return job_id
 
 

--- a/slurmpy/slurmpy.py
+++ b/slurmpy/slurmpy.py
@@ -168,18 +168,14 @@ class Slurm(object):
                 mid = "--dependency=afternotok:%d" % job_id
                 args.append(mid)
             args.append(sh.name)
-            try:
-                res = subprocess.check_output(args).strip()
-                print(res.decode(), file=sys.stderr)
-                self.name = n
-                if not res.startswith(b"Submitted batch"):
-                    return None
-                j_id = int(res.split()[-1])
-                if itry == 1:
-                    job_id = j_id
-            except Exception as e:
-                print ("\x1B[31;9m" + 'Error submitting job:' + "\x1B[0m\n")
-                print(e.output.decode())
+            res = subprocess.check_output(args).strip()
+            print(res.decode(), file=sys.stderr)
+            self.name = n
+            if not res.startswith(b"Submitted batch"):
+                return None
+            j_id = int(res.split()[-1])
+            if itry == 1:
+                job_id = j_id
         return job_id
 
 


### PR DESCRIPTION
This MR makes following modifications to facilitate printing error messages when job submission fails.  

~1. Adds try-except block when submitting jobs to print error messages directly in the terminal.~
2. Prints stdout from job submission (`res`) as typical string instead of binary string. 

