### PR TITLE
Fix: SLURM job dependency format.

### DIFF
--- a/slurmpy/slurmpy.py
+++ b/slurmpy/slurmpy.py
@@ -162,12 +162,6 @@ class Slurm(object):
         job_id = None
         for itry in range(1, tries + 1):
             args = [_cmd]
-            # args.extend([("--dependency=afterok:%d" % int(d))
-            #              for d in depends_on])
-            # if itry > 1:
-            #     mid = "--dependency=afternotok:%d" % job_id
-            #     args.append(mid)
-
             # 20200630
             # sbatch job dependency has the following format
             # -d, --dependency=<dependency_list>
@@ -191,10 +185,8 @@ class Slurm(object):
             # Add dependency option to sbatch
             if dependencies:
                 args.extend(["--dependency=%s" % dependencies])
-            print(args, file=sys.stderr)
             args.append(sh.name)
             res = subprocess.check_output(args).strip()
-            print(res, file=sys.stderr)
             self.name = n
             if not res.startswith(b"Submitted batch"):
                 return None


### PR DESCRIPTION
Hi Brent,

Thanks for this package it automates a lot of the work needed to create SLURM pipelines.

I've found what I think is a bug, related to sbatch job dependency declaration.
The format according to  https://slurm.schedmd.com/sbatch.html is: 
-d, --dependency=<dependency_list>, where <dependency_list> is of the form <type:job_id[:job_id][,type:job_id[:job_id]]> or <type:job_id[:job_id][?type:job_id[:job_id]]>.

The code in slurmpy.py creates multiple --dependency arguments which is not correct it it makes sbatch to capture as dependency only the last --dependency.

I've left the old code in to compare.

Best,
Christos